### PR TITLE
Added Mind Reader to the VS Code Marketplace

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "homepage": "https://github.com/jcode999/Mind_Reader/wiki",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jcode999/Mind_Reader.git"
+    "url": "git+https://github.com/kelsvilla/LegoMindstormsVSExtension"
   },
+  "publisher": "SpamArtists",
   "bugs": {
     "url": "https://github.com/jcode999/Mind_Reader/issues"
   },
@@ -23,7 +24,11 @@
     "Jigme Rinji Sherpa <jigmesherpa@my.unt.edu>",
     "Clay Lewis <ClayLewis2@my.unt.edu>",
     "Haris Javed <harisjaved@my.unt.edu>",
-    "Saad Javed <saadjaved@my.unt.edu>"
+    "Saad Javed <saadjaved@my.unt.edu>",
+    "Kevin Gautier <kevingautier@my.unt.edu>",
+    "Alex Tomjack <Alextomjack@my.unt.edu>",
+    "Kelsee Villareal <KelseeVillareal@my.unt.edu>",
+    "Bryan Tang <BryanTang@my.unt.edu>"
   ],
   "version": "3.0.0",
   "engines": {


### PR DESCRIPTION
#Changes
Added properties needed for publishing the extension in `package.json`
The extension has been published to the VS Code Marketplace
Added the Spam Artist team members to the `package.json`

#Testing
1. On VS Code, click on the extensions tab
2. Search for "Mind Reader"