### PR TITLE
H8 voice overlap fix

### DIFF
--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -491,10 +491,10 @@ function runCursorContext(): void {
 }
 
 function goToSyntaxErrors(): void {
-	// Checks if there is an editor open
-	if (!window || !window.activeTextEditor) {
-		return;
-	}
+    say.stop();
+
+    // Checks if there is an editor open
+    if (!window || !window.activeTextEditor) { return; }
 
 	// get file path
 	const currentFileURI: Uri = window.activeTextEditor.document.uri;

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -491,10 +491,12 @@ function runCursorContext(): void {
 }
 
 function goToSyntaxErrors(): void {
-    say.stop();
+	say.stop();
 
-    // Checks if there is an editor open
-    if (!window || !window.activeTextEditor) { return; }
+	// Checks if there is an editor open
+	if (!window || !window.activeTextEditor) {
+		return;
+	}
 
 	// get file path
 	const currentFileURI: Uri = window.activeTextEditor.document.uri;


### PR DESCRIPTION
### Changes
- fixed tts overlapping bug*

### Testing
1. Run the extension (F5)
2. Click on the Go To Syntax Error command or press Ctrl/Cmd + Shift + Space hotkey repeatedly.
3. The previous message should be stopped and the new one should start

### Note
\* The fix fully works on macOS and partially on Windows. For Windows, it works for the first couple of times and starts to overlap again. So if anyone knows another way, lmk.