### PR TITLE
H8 cycle errors multiple files

### DIFF
--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -543,6 +543,9 @@ async function goToSyntaxErrors(): Promise<void> {
 	if (nextProblemFileObj === undefined) {
 		nextProblemFileIndex = 0;
 		nextProblemFileObj = globalProblems[0];
+		await window.showTextDocument(nextProblemFileObj.uri);
+		moveCursorBeginning();
+		return;
 	}
 
 	// gets the next problem in the problems array
@@ -563,7 +566,6 @@ async function goToSyntaxErrors(): Promise<void> {
 	// if statement for moving cursor position or changing activeTextEditor
 	if (nextProblems.length > 0) {
 		// next problem within same file
-		console.log("same file");
 		window.activeTextEditor.selection = new Selection(
 			nextProblems[0].position,
 			nextProblems[0].position,
@@ -572,13 +574,11 @@ async function goToSyntaxErrors(): Promise<void> {
 		// next problem not in same file
 		if (nextProblemFileIndex < globalProblems.length - 1) {
 			// next problem in next file
-			console.log("next file");
 			nextProblemFileObj = globalProblems[nextProblemFileIndex + 1];
 			await window.showTextDocument(nextProblemFileObj.uri);
 			moveCursorBeginning();
 		} else {
 			// last problem, go to first problem of first file
-			console.log("first file");
 			await window.showTextDocument(globalProblems[0].uri);
 			moveCursorBeginning();
 		}

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -539,6 +539,12 @@ async function goToSyntaxErrors(): Promise<void> {
 		(e) => e.uri.path === currentFilePath,
 	);
 
+	// select first error file if cursor is on file without errors
+	if (nextProblemFileObj === undefined) {
+		nextProblemFileIndex = 0;
+		nextProblemFileObj = globalProblems[0];
+	}
+
 	// gets the next problem in the problems array
 	nextProblems = nextProblemFileObj!.problems.filter((problem) => {
 		if (problem.position.line > cursorPosition.line) {


### PR DESCRIPTION
# Changes
Added feature where user can cycle through files with errors

# Testing
1. Run the extension
2. On the debug VS Code window, make multiple files have some sort of error
3. Press Ctrl/Cmd + Shift + Space repeatedly to cycle through the errors. There are three scenarios
    - more errors after cursor, goes to next error of the current file
    - no errors after the cursor, goes to the top of the file of the next text document known to the editor that has errors
    - no errors after the cursor of the last file known to the editor, goes to the top of the file of the first text document known to the editor that has errors.