### PR TITLE
fixed scrolling problem when going to error

### DIFF
--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -9,6 +9,7 @@ import {
 	languages,
 	window,
 	workspace,
+    Range
 } from "vscode";
 import { CommandEntry } from "./commandEntry";
 
@@ -569,6 +570,7 @@ async function goToSyntaxErrors(): Promise<void> {
 			nextProblems[0].position,
 			nextProblems[0].position,
 		);
+        window.activeTextEditor.revealRange(new Range(nextProblems[0].position, nextProblems[0].position));
 		window.showInformationMessage(nextProblems[0].message);
 		outputMessage(nextProblems[0].message);
 	} else if (nextProblems.length === 0) {


### PR DESCRIPTION
#Changes
- H8 now scrolls to the error if the error is out of the visible range of the text editor

#Testing
1. Run the extension
2. Open a long `.py` file
    - have some errors scattered throughout so that it can be out of visible range. You can also open the VS Code terminal; it will shrink the active text editor's window, which will reduce the visible range.
3. Press Ctrl/Cmd + Shift + Space or click on "Go to syntax errors" command in Access Actions

#Notes   
Pretty much pulled this bit of code out of the moveCursorToBeginning() function