### PR TITLE
Added fix for Say.js not properly cancelling audios on Windows.

### DIFF
--- a/dependencies/say/.travis.yml
+++ b/dependencies/say/.travis.yml
@@ -1,0 +1,6 @@
+language:
+  - javascript
+install:
+  - npm install
+script:
+  - npm run lint

--- a/dependencies/say/LICENSE.txt
+++ b/dependencies/say/LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2010 Marak Squires http://github.com/marak/say.js/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/dependencies/say/README.md
+++ b/dependencies/say/README.md
@@ -1,0 +1,125 @@
+<img src="https://travis-ci.org/Marak/say.js.svg?branch=master" />
+
+<img src="https://github.com/Marak/say.js/raw/master/logo.png" />
+
+## Installing say.js
+
+```bash
+npm install say
+```
+
+
+## Usage
+
+```javascript
+// automatically pick platform
+const say = require('say')
+
+// or, override the platform
+const Say = require('say').Say
+const say = new Say('darwin' || 'win32' || 'linux')
+
+// Use default system voice and speed
+say.speak('Hello!')
+
+// Stop the text currently being spoken
+say.stop()
+
+// More complex example (with an OS X voice) and slow speed
+say.speak("What's up, dog?", 'Alex', 0.5)
+
+// Fire a callback once the text has completed being spoken
+say.speak("What's up, dog?", 'Good News', 1.0, (err) => {
+  if (err) {
+    return console.error(err)
+  }
+
+  console.log('Text has been spoken.')
+});
+
+// Export spoken audio to a WAV file
+say.export("I'm sorry, Dave.", 'Cellos', 0.75, 'hal.wav', (err) => {
+  if (err) {
+    return console.error(err)
+  }
+
+  console.log('Text has been saved to hal.wav.')
+})
+```
+
+### Methods
+
+#### Speak:
+
+* Speed: 1 = 100%, 0.5 = 50%, 2 = 200%, etc
+
+```javascript
+say.speak(text, voice || null, speed || null, callback || null)
+```
+
+#### Export Audio:
+
+* MacOS / Windows Only
+* Speed: 1 = 100%, 0.5 = 50%, 2 = 200%, etc
+
+```javascript
+say.export(text, voice || null, speed || null, filename, callback || null)
+```
+
+#### Stop Speaking:
+
+```javascript
+say.stop(callback || null)
+```
+
+#### Get List of Installed Voice(s):
+
+```javascript
+say.getInstalledVoices(callback)
+```
+
+## Feature Matrix
+
+Unfortunately every feature isn't supported on every platform. PR's welcome!
+
+Platform | Speak | Export | Stop | Speed | Voice | List
+---------|-------|--------|------|-------|-------|-----
+macOS    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :no_entry_sign:
+Linux    | :white_check_mark: | :no_entry_sign:    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :no_entry_sign:
+Windows  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+
+
+## macOS Notes
+
+Voices in macOS are associated with different localities. To a list of voices and their localities run the following command:
+
+```sh
+say -v "?"
+```
+
+As an example, the default voice is `Alex` and the voice used by Siri is `Samantha`.
+
+
+## Windows Notes
+
+None.
+
+## Linux Notes
+
+Linux support requires [Festival](http://www.cstr.ed.ac.uk/projects/festival/). As far as I can tell there is no sane way to get a list of available voices. The only voice that seems to work is `voice_kal_diphone`, which seems to be the default anyway.
+
+The `.export()` method is not available.
+
+Try the following command to install Festival with a default voice:
+
+```shell
+sudo apt-get install festival festvox-kallpc16k
+```
+
+
+## Requirements
+
+* Mac OS X (comes with `say`)
+* Linux with Festival installed
+* Windows (comes with SAPI.SpVoice)
+  * Needs to have Powershell installed and available in $PATH (see [issue #75](https://github.com/Marak/say.js/issues/75))

--- a/dependencies/say/index.d.ts
+++ b/dependencies/say/index.d.ts
@@ -1,0 +1,16 @@
+declare module 'say' {
+  const say: SayJS.Say;
+
+  namespace SayJS {
+    type errorCallback = (err: string) => void;
+
+    class Say {
+      public export(text: string, voice?: string, speed?: number, filePath?: string, callback?: errorCallback): void;
+      public speak(text: string, voice?: string, speed?: number, callback?: errorCallback): void;
+      public stop(): void;
+      public getInstalledVoices(callback: errorCallback): void;
+    }
+  }
+
+  export = say;
+}

--- a/dependencies/say/index.js
+++ b/dependencies/say/index.js
@@ -1,0 +1,33 @@
+const SayLinux = require('./platform/linux.js')
+const SayMacos = require('./platform/darwin.js')
+const SayWin32 = require('./platform/win32.js')
+
+const MACOS = 'darwin'
+const LINUX = 'linux'
+const WIN32 = 'win32'
+
+class Say {
+  constructor (platform) {
+    if (!platform) {
+      platform = process.platform
+    }
+
+    if (platform === MACOS) {
+      return new SayMacos()
+    } else if (platform === LINUX) {
+      return new SayLinux()
+    } else if (platform === WIN32) {
+      return new SayWin32()
+    }
+
+    throw new Error(`new Say(): unsupported platorm! ${platform}`)
+  }
+}
+
+module.exports = new Say() // Create a singleton automatically for backwards compatability
+module.exports.Say = Say // Allow users to `say = new Say.Say(platform)`
+module.exports.platforms = {
+  WIN32: WIN32,
+  MACOS: MACOS,
+  LINUX: LINUX
+}

--- a/dependencies/say/package.json
+++ b/dependencies/say/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "say",
+  "description": "TTS (Text To Speech) Module for Node.js",
+  "version": "0.16.0",
+  "author": "Marak Squires",
+  "license": "MIT",
+  "scripts": {
+    "test": "standard && ./examples/basic-callback.js",
+    "lint": "standard",
+    "lint-fix": "standard --fix"
+  },
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/Marak/say.js.git"
+  },
+  "typings": "index.d.ts",
+  "engines": {
+    "node": ">=6.9"
+  },
+  "devDependencies": {
+    "standard": "^12.0.1"
+  },
+  "dependencies": {
+    "one-time": "0.0.4"
+  }
+}

--- a/dependencies/say/platform/base.js
+++ b/dependencies/say/platform/base.js
@@ -1,0 +1,192 @@
+const childProcess = require('child_process');
+const once = require('one-time');
+
+class SayPlatformBase {
+  constructor () {
+    this.child = null;
+    this.baseSpeed = 0;
+  }
+
+  /**
+   * Uses system libraries to speak text via the speakers.
+   *
+   * @param {string} text Text to be spoken
+   * @param {string|null} voice Name of voice to be spoken with
+   * @param {number|null} speed Speed of text (e.g. 1.0 for normal, 0.5 half, 2.0 double)
+   * @param {Function|null} callback A callback of type function(err) to return.
+   */
+  speak (text, voice, speed, callback) {
+    if (typeof callback !== 'function') {
+      callback = () => {};
+    }
+
+    callback = once(callback);
+
+    if (!text) {
+      return setImmediate(() => {
+        callback(new TypeError('say.speak(): must provide text parameter'));
+      });
+    }
+
+    let { command, args, pipedData, options } = this.buildSpeakCommand({ text, voice, speed });
+
+    this.child = childProcess.spawn(command, args, options);
+
+    this.child.stdin.setEncoding('ascii');
+    this.child.stderr.setEncoding('ascii');
+
+    if (pipedData) {
+      this.child.stdin.end(pipedData);
+    }
+
+    this.child.stderr.once('data', (data) => {
+      // we can't stop execution from this function
+      callback(new Error(data));
+    });
+
+    this.child.addListener('exit', (code, signal) => {
+      if (code === null || signal !== null) {
+        return callback(new Error(`say.speak(): could not talk, had an error [code: ${code}] [signal: ${signal}]`));
+      }
+
+      this.child = null;
+
+      callback(null);
+    });
+  }
+
+  /**
+   * Uses system libraries to speak text via the speakers.
+   *
+   * @param {string} text Text to be spoken
+   * @param {string|null} voice Name of voice to be spoken with
+   * @param {number|null} speed Speed of text (e.g. 1.0 for normal, 0.5 half, 2.0 double)
+   * @param {string} filename Path to file to write audio to, e.g. "greeting.wav"
+   * @param {Function|null} callback A callback of type function(err) to return.
+   */
+  export (text, voice, speed, filename, callback) {
+    if (typeof callback !== 'function') {
+      callback = () => {};
+    }
+
+    callback = once(callback);
+
+    if (!text) {
+      return setImmediate(() => {
+        callback(new TypeError('say.export(): must provide text parameter'));
+      });
+    }
+
+    if (!filename) {
+      return setImmediate(() => {
+        callback(new TypeError('say.export(): must provide filename parameter'));
+      });
+    }
+
+    try {
+      var { command, args, pipedData, options } = this.buildExportCommand({ text, voice, speed, filename });
+    } catch (error) {
+      return setImmediate(() => {
+        callback(error);
+      });
+    }
+
+    this.child = childProcess.spawn(command, args, options);
+
+    this.child.stdin.setEncoding('ascii');
+    this.child.stderr.setEncoding('ascii');
+
+    if (pipedData) {
+      this.child.stdin.end(pipedData);
+    }
+
+    this.child.stderr.once('data', (data) => {
+      // we can't stop execution from this function
+      callback(new Error(data));
+    });
+
+    this.child.addListener('exit', (code, signal) => {
+      if (code === null || signal !== null) {
+        return callback(new Error(`say.export(): could not talk, had an error [code: ${code}] [signal: ${signal}]`));
+      }
+
+      this.child = null;
+
+      callback(null);
+    });
+  }
+
+  /**
+   * Stops currently playing audio. There will be unexpected results if multiple audios are being played at once
+   *
+   * TODO: If two messages are being spoken simultaneously, childD points to new instance, no way to kill previous
+   *
+   * @param {Function|null} callback A callback of type function(err) to return.
+   */
+  stop (callback) {
+    if (typeof callback !== 'function') {
+      callback = () => {};
+    }
+
+    callback = once(callback);
+
+    if (!this.child) {
+      return setImmediate(() => {
+        callback(new Error('say.stop(): no speech to kill'));
+      });
+    }
+
+    this.runStopCommand();
+
+    this.child = null;
+
+    callback(null);
+  }
+
+  convertSpeed (speed) {
+    return Math.ceil(this.baseSpeed * speed);
+  }
+
+  /**
+   * Get Installed voices on system
+   * @param {Function} callback A callback of type function(err,voices) to return.
+   */
+  getInstalledVoices (callback) {
+    if (typeof callback !== 'function') {
+      callback = () => {};
+    }
+    callback = once(callback);
+
+    let { command, args } = this.getVoices();
+    var voices = [];
+    this.child = childProcess.spawn(command, args);
+
+    this.child.stdin.setEncoding('ascii');
+    this.child.stderr.setEncoding('ascii');
+
+    this.child.stderr.once('data', (data) => {
+      // we can't stop execution from this function
+      callback(new Error(data));
+    });
+    this.child.stdout.on('data', function (data) {
+      voices += data;
+    });
+
+    this.child.addListener('exit', (code, signal) => {
+      if (code === null || signal !== null) {
+        return callback(new Error(`say.getInstalledVoices(): could not get installed voices, had an error [code: ${code}] [signal: ${signal}]`));
+      }
+      if (voices.length > 0) {
+        voices = voices.split('\r\n');
+        voices = (voices[voices.length - 1] === '') ? voices.slice(0, voices.length - 1) : voices;
+      }
+      this.child = null;
+
+      callback(null, voices);
+    });
+
+    this.child.stdin.end();
+  }
+}
+
+module.exports = SayPlatformBase;

--- a/dependencies/say/platform/darwin.js
+++ b/dependencies/say/platform/darwin.js
@@ -50,9 +50,10 @@ class SayPlatformDarwin extends SayPlatformBase {
     return { command: COMMAND, args, pipedData, options };
   }
 
-  runStopCommand () {
-    this.child.stdin.pause();
-    this.child.kill();
+  runStopCommand (child) {
+    child.stdin.pause();
+    child.kill();
+    this.children = this.children.filter(e => e.pid !== child.pid);
   }
 
   getVoices () {

--- a/dependencies/say/platform/darwin.js
+++ b/dependencies/say/platform/darwin.js
@@ -1,0 +1,63 @@
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const SayPlatformBase = require('./base.js');
+
+const BASE_SPEED = 175;
+const COMMAND = 'say';
+
+class SayPlatformDarwin extends SayPlatformBase {
+  constructor () {
+    super();
+    this.baseSpeed = BASE_SPEED;
+  }
+
+  buildSpeakCommand ({ text, voice, speed }) {
+    let args = [];
+    let pipedData = '';
+    let options = {};
+
+    if (!voice) {
+      args.push(text);
+    } else {
+      args.push('-v', voice, text);
+    }
+
+    if (speed) {
+      args.push('-r', this.convertSpeed(speed));
+    }
+
+    return { command: COMMAND, args, pipedData, options };
+  }
+
+  buildExportCommand ({ text, voice, speed, filename }) {
+    let args = [];
+    let pipedData = '';
+    let options = {};
+
+    if (!voice) {
+      args.push(text);
+    } else {
+      args.push('-v', voice, text);
+    }
+
+    if (speed) {
+      args.push('-r', this.convertSpeed(speed));
+    }
+
+    if (filename) {
+      args.push('-o', filename, '--data-format=LEF32@32000');
+    }
+
+    return { command: COMMAND, args, pipedData, options };
+  }
+
+  runStopCommand () {
+    this.child.stdin.pause();
+    this.child.kill();
+  }
+
+  getVoices () {
+    throw new Error(`say.export(): does not support platform ${this.platform}`);
+  }
+}
+
+module.exports = SayPlatformDarwin;

--- a/dependencies/say/platform/linux.js
+++ b/dependencies/say/platform/linux.js
@@ -34,12 +34,13 @@ class SayPlatformLinux extends SayPlatformBase {
     throw new Error(`say.export(): does not support platform ${this.platform}`);
   }
 
-  runStopCommand () {
+  runStopCommand (child) {
     // TODO: Need to ensure the following is true for all users, not just me. Danger Zone!
     // On my machine, original childD.pid process is completely gone. Instead there is now a
     // childD.pid + 1 sh process. Kill it and nothing happens. There's also a childD.pid + 2
     // aplay process. Kill that and the audio actually stops.
-    process.kill(this.child.pid + 2);
+    process.kill(child.pid + 2);
+    this.children = this.children.filter(e => e.pid !== child.pid);
   }
 
   getVoices () {

--- a/dependencies/say/platform/linux.js
+++ b/dependencies/say/platform/linux.js
@@ -1,0 +1,50 @@
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const SayPlatformBase = require('./base.js');
+
+const BASE_SPEED = 100;
+const COMMAND = 'festival';
+
+class SayPlatformLinux extends SayPlatformBase {
+  constructor () {
+    super();
+    this.baseSpeed = BASE_SPEED;
+  }
+
+  buildSpeakCommand ({ text, voice, speed }) {
+    let args = [];
+    let pipedData = '';
+    let options = {};
+
+    args.push('--pipe');
+
+    if (speed) {
+      pipedData += `(Parameter.set 'Audio_Command "aplay -q -c 1 -t raw -f s16 -r $(($SR*${this.convertSpeed(speed)}/100)) $FILE") `;
+    }
+
+    if (voice) {
+      pipedData += `(${voice}) `;
+    }
+
+    pipedData += `(SayText "${text}")`;
+
+    return { command: COMMAND, args, pipedData, options };
+  }
+
+  buildExportCommand ({ text, voice, speed, filename }) {
+    throw new Error(`say.export(): does not support platform ${this.platform}`);
+  }
+
+  runStopCommand () {
+    // TODO: Need to ensure the following is true for all users, not just me. Danger Zone!
+    // On my machine, original childD.pid process is completely gone. Instead there is now a
+    // childD.pid + 1 sh process. Kill it and nothing happens. There's also a childD.pid + 2
+    // aplay process. Kill that and the audio actually stops.
+    process.kill(this.child.pid + 2);
+  }
+
+  getVoices () {
+    throw new Error(`say.export(): does not support platform ${this.platform}`);
+  }
+}
+
+module.exports = SayPlatformLinux;

--- a/dependencies/say/platform/win32.js
+++ b/dependencies/say/platform/win32.js
@@ -67,14 +67,10 @@ class SayPlatformWin32 extends SayPlatformBase {
     return { command: COMMAND, args, pipedData, options };
   }
 
-  runStopCommand (pid) {
-    pid = pid ? pid : this.child.pid;
-    if(!pid) {
-      return;
-    }
-    this.child.stdin.pause();
-    childProcess.exec(`taskkill /pid ${pid} /T /F`);
-    this.childIDs = this.childIDs.filter((id) => id !== pid);
+  runStopCommand (child) {
+    child.stdin.pause();
+    childProcess.exec(`taskkill /pid ${child.pid} /T /F`);
+    this.children = this.children.filter(e => e.pid !== child.pid);
   }
 
   convertSpeed (speed) {

--- a/dependencies/say/platform/win32.js
+++ b/dependencies/say/platform/win32.js
@@ -74,7 +74,7 @@ class SayPlatformWin32 extends SayPlatformBase {
     }
     this.child.stdin.pause();
     childProcess.exec(`taskkill /pid ${pid} /T /F`);
-    this.childIDs.filter((id) => id !== pid);
+    this.childIDs = this.childIDs.filter((id) => id !== pid);
   }
 
   convertSpeed (speed) {

--- a/dependencies/say/platform/win32.js
+++ b/dependencies/say/platform/win32.js
@@ -1,0 +1,88 @@
+const childProcess = require('child_process');
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const SayPlatformBase = require('./base.js');
+
+const BASE_SPEED = 0; // Unsupported
+const COMMAND = 'powershell';
+
+class SayPlatformWin32 extends SayPlatformBase {
+  constructor () {
+    super();
+    this.baseSpeed = BASE_SPEED;
+  }
+
+  buildSpeakCommand ({ text, voice, speed }) {
+    let args = [];
+    let pipedData = '';
+    let options = {};
+
+    let psCommand = `Add-Type -AssemblyName System.speech;$speak = New-Object System.Speech.Synthesis.SpeechSynthesizer;`;
+
+    if (voice) {
+      psCommand += `$speak.SelectVoice('${voice}');`;
+    }
+
+    if (speed) {
+      let adjustedSpeed = this.convertSpeed(speed || 1);
+      psCommand += `$speak.Rate = ${adjustedSpeed};`;
+    }
+
+    psCommand += `$speak.Speak([Console]::In.ReadToEnd())`;
+
+    pipedData += text;
+    args.push(psCommand);
+    options.shell = true;
+
+    return { command: COMMAND, args, pipedData, options };
+  }
+
+  buildExportCommand ({ text, voice, speed, filename }) {
+    let args = [];
+    let pipedData = '';
+    let options = {};
+
+    let psCommand = `Add-Type -AssemblyName System.speech;$speak = New-Object System.Speech.Synthesis.SpeechSynthesizer;`;
+
+    if (voice) {
+      psCommand += `$speak.SelectVoice('${voice}');`;
+    }
+
+    if (speed) {
+      let adjustedSpeed = this.convertSpeed(speed || 1);
+      psCommand += `$speak.Rate = ${adjustedSpeed};`;
+    }
+
+    if (!filename) {throw new Error('Filename must be provided in export();');}
+    else {
+      psCommand += `$speak.SetOutputToWaveFile('${filename}');`;
+    }
+
+    psCommand += `$speak.Speak([Console]::In.ReadToEnd());$speak.Dispose()`;
+
+    pipedData += text;
+    args.push(psCommand);
+    options.shell = true;
+
+    return { command: COMMAND, args, pipedData, options };
+  }
+
+  runStopCommand () {
+    this.child.stdin.pause();
+    childProcess.exec(`taskkill /pid ${this.child.pid} /T /F`);
+  }
+
+  convertSpeed (speed) {
+    // Overriden to map playback speed (as a ratio) to Window's values (-10 to 10, zero meaning x1.0)
+    return Math.max(-10, Math.min(Math.round((9.0686 * Math.log(speed)) - 0.1806), 10));
+  }
+
+  getVoices () {
+    let args = [];
+    let psCommand = 'Add-Type -AssemblyName System.speech;$speak = New-Object System.Speech.Synthesis.SpeechSynthesizer;$speak.GetInstalledVoices() | % {$_.VoiceInfo.Name}';
+    args.push(psCommand);
+    return { command: COMMAND, args };
+  }
+}
+
+module.exports = SayPlatformWin32;

--- a/dependencies/say/platform/win32.js
+++ b/dependencies/say/platform/win32.js
@@ -67,9 +67,14 @@ class SayPlatformWin32 extends SayPlatformBase {
     return { command: COMMAND, args, pipedData, options };
   }
 
-  runStopCommand () {
+  runStopCommand (pid) {
+    pid = pid ? pid : this.child.pid;
+    if(!pid) {
+      return;
+    }
     this.child.stdin.pause();
-    childProcess.exec(`taskkill /pid ${this.child.pid} /T /F`);
+    childProcess.exec(`taskkill /pid ${pid} /T /F`);
+    this.childIDs.filter((id) => id !== pid);
   }
 
   convertSpeed (speed) {

--- a/dependencies/say/typings.json
+++ b/dependencies/say/typings.json
@@ -1,0 +1,4 @@
+{
+  "name": "say",
+  "main": "index.d.ts"
+}

--- a/package.json
+++ b/package.json
@@ -824,7 +824,7 @@
 		"jzz": "^1.7.4",
 		"midi": "^2.0.0",
 		"play-sound": "^1.1.6",
-		"say": "^0.16.0",
+		"say": "file:./dependencies/say",
 		"serialport": "^11.0.0",
 		"server": "^1",
 		"speech-synthesis": "^0.3.2",

--- a/src/client01.ts
+++ b/src/client01.ts
@@ -4,15 +4,15 @@ import * as path from "path";
 var os = require("os");
 const { spawn } = require("child_process");
 import { rootDir } from "./extension";
-import {
-	CommandEntry,
-	accessCommands,
-	hubCommands,
-	navCommands,
-	textCommands,
-	voicetotextCommands,
-	midicommands,
-} from "./commands";
+// import {
+// 	CommandEntry,
+// 	accessCommands,
+// 	hubCommands,
+// 	navCommands,
+// 	textCommands,
+// 	voicetotextCommands,
+// 	midicommands,
+// } from "./commands";
 
 function activateVoiceServer() {
 	//activate server
@@ -31,6 +31,7 @@ function activateVoiceServer() {
 		cwd: normalizedProjectRoot,
 		env: {
 			...process.env,
+			// eslint-disable-next-line @typescript-eslint/naming-convention
 			SPACY_DATA: path.join(
 				normalizedProjectRoot,
 				"dependencies",
@@ -60,14 +61,16 @@ function runClient(commandHistory: string[]) {
 	});
 
 	socket.on("message", async (message) => {
-		//console.log("message recived", message.toString());
 		if (message.toString() !== "Shutting down voice commands.") {
-			if (message.toString().split(",").length !== 2) return; //Ensures both vars below will be defined with some value
+			if (message.toString().split(",").length !== 2) {
+				return; //Ensures both vars below will be defined with some value
+			}
 			const [cmdName, logMsg] = message.toString().split(",");
-			//console.log(`cmd: ${cmdName}\nlog:${logMsg}`);
 			try {
-				if (cmdName == "undo") {
-					if (commandHistory.length > 0) commandHistory.pop();
+				if (cmdName === "undo") {
+					if (commandHistory.length > 0) {
+						commandHistory.pop();
+					}
 				} else if (cmdName !== "") {
 					await vscode.commands.executeCommand(cmdName);
 					commandHistory.push(cmdName);

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -570,6 +570,7 @@ async function goToSyntaxErrors(): Promise<void> {
 			nextProblems[0].position,
 		);
 		window.showInformationMessage(nextProblems[0].message);
+		outputMessage(nextProblems[0].message);
 	} else if (nextProblems.length === 0) {
 		// next problem not in same file
 		if (nextProblemFileIndex < globalProblems.length - 1) {


### PR DESCRIPTION
# Changes
- (Unrelated) Fixed ESLint warnings in `client01.ts`.
- Moved the `say` package to `dependencies`. Updated `package.json` dependencies to reflect the new path.
- Fixed ESLint warnings in `say` since we are taking control of the code.
- Updated `base.js` and `win32.js` to fix bug where audios would play over each other on Windows.

# Testing
(Changes are only supposed to affect Windows, but please test on another platform to ensure no side-effects.)
- Run the extension
- Run the 'Toggle Text to Speech' command.
- Activate several TTS audios in rapid succession, ensuring they do not speak over each other.