### PR TITLE
H8 include file name

### DIFF
--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -477,7 +477,6 @@ function runCursorContext(): void {
 			contextEnd = Math.min(spaceWords.length, i + windowSize + 1); // clamp end index
 			// construct cursor context string
 			let contextString: string = "";
-
 			for (let i: number = contextStart; i < contextEnd; i++) {
 				contextString += spaceWords[i].word + " ";
 			}
@@ -571,8 +570,11 @@ async function goToSyntaxErrors(): Promise<void> {
 			nextProblems[0].position,
 		);
         window.activeTextEditor.revealRange(new Range(nextProblems[0].position, nextProblems[0].position));
-		window.showInformationMessage(nextProblems[0].message);
-		outputMessage(nextProblems[0].message);
+
+		let fileName = window.activeTextEditor.document.uri.fsPath.match(/((?:[^\/\r\n]*){1})$/g);
+		let errorMessage = fileName!.toString().replace(',', '');
+		let message = errorMessage + ": " + nextProblems[0].message;
+		outputMessage(message);
 	} else if (nextProblems.length === 0) {
 		// next problem not in same file
 		if (nextProblemFileIndex < globalProblems.length - 1) {

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -571,9 +571,12 @@ async function goToSyntaxErrors(): Promise<void> {
 		);
         window.activeTextEditor.revealRange(new Range(nextProblems[0].position, nextProblems[0].position));
 
-		let fileName = window.activeTextEditor.document.uri.fsPath.match(/((?:[^\/\r\n]*){1})$/g);
-		let errorMessage = fileName!.toString().replace(',', '');
-		let message = errorMessage + ": " + nextProblems[0].message;
+        let path = window.activeTextEditor.document.uri.fsPath;
+        path = path.replace("\/", "\\");
+		let fileName = path.match(/((?:[^\\|\/]*){1})$/g)?.toString();
+		fileName = fileName!.replace(',', '');
+		let message = fileName + ": " + nextProblems[0].message;
+
 		outputMessage(message);
 	} else if (nextProblems.length === 0) {
 		// next problem not in same file


### PR DESCRIPTION
## Changes
- Added file name to error message

## Testing
1. Run the extension
2. Open a .py file that contains an error
3. Click 'Go To Syntax Errors' on the Access Actions, or press Ctrl/Cmd + Shift + Space
4. A message should appear which contains the file's name and the error.

## Notes
Turning on TTS should also make it read out the file's name and message.