### PR TITLE
add tabgroup jumping; updated vscode types

### DIFF
--- a/package.json
+++ b/package.json
@@ -806,7 +806,7 @@
 		"@types/node": "16.x",
 		"@types/play-sound": "^1.1.2",
 		"@types/serialport": "^8.0.2",
-		"@types/vscode": "^1.60.0",
+		"@types/vscode": "^1.86.0",
 		"@types/ws": "^6.0.0",
 		"@typescript-eslint/eslint-plugin": "^4.26.0",
 		"@typescript-eslint/parser": "^4.26.0",

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -9,55 +9,57 @@ import {
 	languages,
 	window,
 	workspace,
-    Range
+    Range,
+    commands,
+    TabGroup
 } from "vscode";
 import { CommandEntry } from "./commandEntry";
 
 export const textCommands: CommandEntry[] = [
-	{
-		name: "mind-reader.getLineNumber",
-		callback: getLineNumber,
-	},
-	{
-		name: "mind-reader.getIndent",
-		callback: getIndent,
-	},
-	{
-		name: "mind-reader.getLeadingSpaces",
-		callback: getLeadingSpaces,
-	},
-	{
-		name: "mind-reader.selectLeadingWhitespace",
-		callback: selectLeadingWhitespace,
-	},
-	{
-		name: "mind-reader.getNumberOfSelectedLines",
-		callback: getNumberOfSelectedLines,
-	},
-	{
-		name: "mind-reader.getLineScope",
-		callback: runLineContext,
-	},
-	{
-		name: "mind-reader.getWordsUnderCursor",
-		callback: runCursorContext,
-	},
-	{
-		name: "mind-reader.toggleTextToSpeech",
-		callback: toggleTTS,
-	},
-	{
-		name: "mind-reader.goToSyntaxErrors",
-		callback: goToSyntaxErrors,
-	},
-	{
-		name: "mind-reader.moveCursorBeginning",
-		callback: moveCursorBeginning,
-	},
-	{
-		name: "mind-reader.moveCursorEnd",
-		callback: moveCursorEnd,
-	},
+    {
+        name: "mind-reader.getLineNumber",
+        callback: getLineNumber,
+    },
+    {
+        name: "mind-reader.getIndent",
+        callback: getIndent,
+    },
+    {
+        name: "mind-reader.getLeadingSpaces",
+        callback: getLeadingSpaces,
+    },
+    {
+        name: "mind-reader.selectLeadingWhitespace",
+        callback: selectLeadingWhitespace,
+    },
+    {
+        name: "mind-reader.getNumberOfSelectedLines",
+        callback: getNumberOfSelectedLines,
+    },
+    {
+        name: "mind-reader.getLineScope",
+        callback: runLineContext,
+    },
+    {
+        name: "mind-reader.getWordsUnderCursor",
+        callback: runCursorContext,
+    },
+    {
+        name: "mind-reader.toggleTextToSpeech",
+        callback: toggleTTS,
+    },
+    {
+        name: "mind-reader.goToSyntaxErrors",
+        callback: goToSyntaxErrors,
+    },
+    {
+        name: "mind-reader.moveCursorBeginning",
+        callback: moveCursorBeginning,
+    },
+    {
+        name: "mind-reader.moveCursorEnd",
+        callback: moveCursorEnd,
+    },
 ];
 
 /** Helper Function
@@ -82,54 +84,54 @@ export const textCommands: CommandEntry[] = [
 let shouldSpeak = false;
 
 function outputMessage(message: string) {
-	window.showInformationMessage(message);
-	shouldSpeak === true ? say.speak(message) : undefined;
+    window.showInformationMessage(message);
+    shouldSpeak === true ? say.speak(message) : undefined;
 }
 
 function toggleTTS() {
-	shouldSpeak = !shouldSpeak;
-	shouldSpeak
-	? window.showInformationMessage("Text to Speech Activated")
-	: window.showInformationMessage("Text to Speech Deactivated");
+    shouldSpeak = !shouldSpeak;
+    shouldSpeak
+        ? window.showInformationMessage("Text to Speech Activated")
+        : window.showInformationMessage("Text to Speech Deactivated");
 }
 
 export function fetchNumberOfLeadingSpaces(editor: TextEditor | undefined): number {
-	let numSpaces: number = 0;
+    let numSpaces: number = 0;
 
-	if (editor) {
-		/*
-		 * set  true to use method 1: find the number of leading spaces through arithmetic
-		 * set false to use method 2: find the index position of the first non-whitespace character in a 0-index
-		 * default: false
-		 */
-		const calculateLeadingSpaces: boolean = false; // change boolean value to change method
-		const line: TextLine = fetchLine(editor);
+    if (editor) {
+        /*
+         * set  true to use method 1: find the number of leading spaces through arithmetic
+         * set false to use method 2: find the index position of the first non-whitespace character in a 0-index
+         * default: false
+         */
+        const calculateLeadingSpaces: boolean = false; // change boolean value to change method
+        const line: TextLine = fetchLine(editor);
 
-		/* If true, calculate by arithmetic otherwise get index */
-		numSpaces = calculateLeadingSpaces
-			? pl.Lexer.getLeadingSpacesByArithmetic(line)
-			: pl.Lexer.getLeadingSpacesByIndex(line);
-	}
+        /* If true, calculate by arithmetic otherwise get index */
+        numSpaces = calculateLeadingSpaces
+            ? pl.Lexer.getLeadingSpacesByArithmetic(line)
+            : pl.Lexer.getLeadingSpacesByIndex(line);
+    }
 
-	return numSpaces;
+    return numSpaces;
 }
 
 /** Helper Function
 * * This function returns the number of selected lines in the active text editor window
-	@param editor
-	@returns numberOfSelectedLines
+    @param editor
+    @returns numberOfSelectedLines
 */
 export function fetchNumberOfSelectedLines(editor: TextEditor | undefined): number {
-	let numberOfSelectedLines: number = 0;
+    let numberOfSelectedLines: number = 0;
 
-	if (editor) {
-		numberOfSelectedLines = editor.selections.reduce(
-			(prev, curr) => prev + (curr.end.line - curr.start.line),
-			1,
-		);
-	}
+    if (editor) {
+        numberOfSelectedLines = editor.selections.reduce(
+            (prev, curr) => prev + (curr.end.line - curr.start.line),
+            1,
+        );
+    }
 
-	return numberOfSelectedLines;
+    return numberOfSelectedLines;
 }
 
 /** Helper Function
@@ -138,7 +140,7 @@ export function fetchNumberOfSelectedLines(editor: TextEditor | undefined): numb
  *  @returns editor!.selection.active.line + 1
  */
 export function fetchLineNumber(editor: TextEditor | undefined): number {
-	return editor!.selection.active.line + 1; // line numbers start at 1, not 0, so we add 1 to the result
+    return editor!.selection.active.line + 1; // line numbers start at 1, not 0, so we add 1 to the result
 }
 
 /** Helper Function
@@ -147,7 +149,7 @@ export function fetchLineNumber(editor: TextEditor | undefined): number {
  *  @returns editor.document.lineAt(fetchLineNumber(editor) - 1)
  */
 export function fetchLine(editor: TextEditor | undefined): TextLine {
-	return editor!.document.lineAt(fetchLineNumber(editor) - 1); // We want the line index, so we remove the 1 we added to the result in fetchLineNumber
+    return editor!.document.lineAt(fetchLineNumber(editor) - 1); // We want the line index, so we remove the 1 we added to the result in fetchLineNumber
 }
 
 /* Function
@@ -155,138 +157,138 @@ export function fetchLine(editor: TextEditor | undefined): TextLine {
  * Changes output to 'Line' for 1 line and 'Lines' for all other instances
  */
 function getNumberOfSelectedLines(): void {
-	const editor: TextEditor | undefined = window.activeTextEditor;
+    const editor: TextEditor | undefined = window.activeTextEditor;
 
-	if (editor) {
-		const numberOfSelectedLines: number =
-			fetchNumberOfSelectedLines(editor);
+    if (editor) {
+        const numberOfSelectedLines: number =
+            fetchNumberOfSelectedLines(editor);
 
-		const message =
-			numberOfSelectedLines !== 1
-				? `${numberOfSelectedLines.toString()} Lines Selected`
-				: `${numberOfSelectedLines.toString()} Line Selected`;
+        const message =
+            numberOfSelectedLines !== 1
+                ? `${numberOfSelectedLines.toString()} Lines Selected`
+                : `${numberOfSelectedLines.toString()} Line Selected`;
 
-		// Show the message to the user
-		outputMessage(message);
-	} else {
-		window.showErrorMessage("No document currently active");
-	}
+        // Show the message to the user
+        outputMessage(message);
+    } else {
+        window.showErrorMessage("No document currently active");
+    }
 }
 
 /*  Function
  *  Outputs the current line number the cursor is on
  */
 export function getLineNumber(): void {
-	const editor: TextEditor | undefined = window.activeTextEditor;
+    const editor: TextEditor | undefined = window.activeTextEditor;
 
-	if (editor) {
-		const lineNum: number = fetchLineNumber(editor);
+    if (editor) {
+        const lineNum: number = fetchLineNumber(editor);
 
-		const message = `Line ${lineNum.toString()}`;
-		outputMessage(message);
-	} else {
-		window.showErrorMessage("No document currently active");
-	}
+        const message = `Line ${lineNum.toString()}`;
+        outputMessage(message);
+    } else {
+        window.showErrorMessage("No document currently active");
+    }
 }
 
 /* Function
  * Used to get the number of indents on a line
  */
 export function getIndent(): number {
-	const editor: TextEditor | undefined = window.activeTextEditor;
+    const editor: TextEditor | undefined = window.activeTextEditor;
 
-	if (editor) {
-		const lineNum: number = fetchLineNumber(editor);
-		const line: TextLine = fetchLine(editor);
+    if (editor) {
+        const lineNum: number = fetchLineNumber(editor);
+        const line: TextLine = fetchLine(editor);
 
-		if (line.isEmptyOrWhitespace) {
-			window.showInformationMessage(
-				`Line ${lineNum.toString()} is Empty`,
-			);
+        if (line.isEmptyOrWhitespace) {
+            window.showInformationMessage(
+                `Line ${lineNum.toString()} is Empty`,
+            );
 
-		} else {
-			// Grab tab format from open document
-			const tabFmt: pl.TabInfo = {
-				size:
-					typeof editor.options.tabSize === "number"
-						? editor.options.tabSize
-						: 4,
-				hard: !editor.options.insertSpaces,
-			};
-			const i: number = pl.Lexer.getIndent(line.text, tabFmt);
+        } else {
+            // Grab tab format from open document
+            const tabFmt: pl.TabInfo = {
+                size:
+                    typeof editor.options.tabSize === "number"
+                        ? editor.options.tabSize
+                        : 4,
+                hard: !editor.options.insertSpaces,
+            };
+            const i: number = pl.Lexer.getIndent(line.text, tabFmt);
 
-			const message =
-				i !== 1
-					? `Line ${lineNum.toString()}: ${i.toString()} indents`
-					: `Line ${lineNum.toString()}: ${i.toString()} indent`;
+            const message =
+                i !== 1
+                    ? `Line ${lineNum.toString()}: ${i.toString()} indents`
+                    : `Line ${lineNum.toString()}: ${i.toString()} indent`;
 
-			outputMessage(message);
-			return i;
-		}
-	} else {
-		window.showErrorMessage("No document currently active");
-		return 0;
-	}
-	return 0;
+            outputMessage(message);
+            return i;
+        }
+    } else {
+        window.showErrorMessage("No document currently active");
+        return 0;
+    }
+    return 0;
 }
 
 /* Function
  * Used to return the number of indents on a line
  */
 export function returnIndent(): Number {
-	const editor: TextEditor | undefined = window.activeTextEditor;
+    const editor: TextEditor | undefined = window.activeTextEditor;
 
-	if (editor) {
-		const line: TextLine = fetchLine(editor);
+    if (editor) {
+        const line: TextLine = fetchLine(editor);
 
-		if (line.isEmptyOrWhitespace) {
-			return 0;
-		} else {
-			// Grab tab format from open document
-			const tabFmt: pl.TabInfo = {
-				size:
-					typeof editor.options.tabSize === "number"
-						? editor.options.tabSize
-						: 4,
-				hard: !editor.options.insertSpaces,
-			};
-			const i: number = pl.Lexer.getIndent(line.text, tabFmt);
+        if (line.isEmptyOrWhitespace) {
+            return 0;
+        } else {
+            // Grab tab format from open document
+            const tabFmt: pl.TabInfo = {
+                size:
+                    typeof editor.options.tabSize === "number"
+                        ? editor.options.tabSize
+                        : 4,
+                hard: !editor.options.insertSpaces,
+            };
+            const i: number = pl.Lexer.getIndent(line.text, tabFmt);
 
-			return i;
-		}
-	} else {
-		return -1;
-	}
+            return i;
+        }
+    } else {
+        return -1;
+    }
 }
 
 /* Function
  * Returns the number of leading spaces on the line the cursor is on
  */
 function getLeadingSpaces(): void {
-	const editor: TextEditor | undefined = window.activeTextEditor;
+    const editor: TextEditor | undefined = window.activeTextEditor;
 
-	if (editor) {
-		const lineNum: number = fetchLineNumber(editor);
-		const line: TextLine | undefined = fetchLine(editor);
+    if (editor) {
+        const lineNum: number = fetchLineNumber(editor);
+        const line: TextLine | undefined = fetchLine(editor);
 
-		if (line.isEmptyOrWhitespace) {
-			window.showInformationMessage(
-				`Line ${lineNum.toString()} is empty`,
-			);
-		} else {
-			const numSpaces = fetchNumberOfLeadingSpaces(editor);
+        if (line.isEmptyOrWhitespace) {
+            window.showInformationMessage(
+                `Line ${lineNum.toString()} is empty`,
+            );
+        } else {
+            const numSpaces = fetchNumberOfLeadingSpaces(editor);
 
-			/* Ternary operator to change the tense of 'space' to 'spaces' for the output if numSpaces is 0 or greater than 1 */
-			const message =
-				numSpaces !== 1
-					? `Line ${lineNum.toString()}: ${numSpaces.toString()} spaces`
-					: `Line ${lineNum.toString()}: ${numSpaces.toString()} space`;
+            /* Ternary operator to change the tense of 'space' to 'spaces' for the output if numSpaces is 0 or greater than 1 */
+            const message =
+                numSpaces !== 1
+                    ? `Line ${lineNum.toString()}: ${numSpaces.toString()} spaces`
+                    : `Line ${lineNum.toString()}: ${numSpaces.toString()} space`;
 
-			outputMessage(message);
-		}
-	} else {
-		window.showErrorMessage("No document currently active");
-	}
+            outputMessage(message);
+        }
+    } else {
+        window.showErrorMessage("No document currently active");
+    }
 }
 
 /* Function
@@ -294,122 +296,122 @@ function getLeadingSpaces(): void {
  * This feature was a request from Senior Design Day Spring 2022
  */
 function selectLeadingWhitespace(): void {
-	const editor: TextEditor | undefined = window.activeTextEditor;
+    const editor: TextEditor | undefined = window.activeTextEditor;
 
-	if (editor) {
-		const numSpaces = fetchNumberOfLeadingSpaces(editor); // This will be used for the output message
-		const lineNum: number = fetchLineNumber(editor); // Get the displayed line number
+    if (editor) {
+        const numSpaces = fetchNumberOfLeadingSpaces(editor); // This will be used for the output message
+        const lineNum: number = fetchLineNumber(editor); // Get the displayed line number
 
-		/* If numSpaces isn't greater than 1, then there is no leading whitespace to select */
-		if (numSpaces >= 1) {
-			const line: TextLine = fetchLine(editor);
-			const startPos: number = line.range.start.character; // Start at the starting character position
-			const endPos: number = line.firstNonWhitespaceCharacterIndex; // End at the first non whitespace character index
+        /* If numSpaces isn't greater than 1, then there is no leading whitespace to select */
+        if (numSpaces >= 1) {
+            const line: TextLine = fetchLine(editor);
+            const startPos: number = line.range.start.character; // Start at the starting character position
+            const endPos: number = line.firstNonWhitespaceCharacterIndex; // End at the first non whitespace character index
 
-			/* Apply our selection */
-			/* We need to subtract 1 from lineNum because we added 1 during the fetchLineNumber above and we want the 0-index for position, so remove it */
-			editor.selection = new Selection(
-				new Position(lineNum - 1, startPos),
-				new Position(lineNum - 1, endPos),
-			);
+            /* Apply our selection */
+            /* We need to subtract 1 from lineNum because we added 1 during the fetchLineNumber above and we want the 0-index for position, so remove it */
+            editor.selection = new Selection(
+                new Position(lineNum - 1, startPos),
+                new Position(lineNum - 1, endPos),
+            );
 
-			/* Ternary operator to change the tense of 'space' to 'spaces' for the output if numSpaces is 0 or greater than 1 */
-			const message =
-				numSpaces !== 1
-					? `Line ${lineNum.toString()}: ${numSpaces.toString()} spaces selected`
-					: `Line ${lineNum.toString()}: ${numSpaces.toString()} space selected`;
-			outputMessage(message);
-			// Move the cursor to the new selection
-			window.showTextDocument(editor.document);
-		} else {
-			window.showErrorMessage(
-				`Line ${lineNum.toString()}: No leading spaces to select!`,
-			); // No whitespace to select
-		}
-	} else {
-		window.showErrorMessage("No document currently active"); // No active document
-	}
+            /* Ternary operator to change the tense of 'space' to 'spaces' for the output if numSpaces is 0 or greater than 1 */
+            const message =
+                numSpaces !== 1
+                    ? `Line ${lineNum.toString()}: ${numSpaces.toString()} spaces selected`
+                    : `Line ${lineNum.toString()}: ${numSpaces.toString()} space selected`;
+            outputMessage(message);
+            // Move the cursor to the new selection
+            window.showTextDocument(editor.document);
+        } else {
+            window.showErrorMessage(
+                `Line ${lineNum.toString()}: No leading spaces to select!`,
+            ); // No whitespace to select
+        }
+    } else {
+        window.showErrorMessage("No document currently active"); // No active document
+    }
 }
 
 function runLineContext(): void {
-	const editor: TextEditor | undefined = window.activeTextEditor;
+    const editor: TextEditor | undefined = window.activeTextEditor;
 
-	if (editor) {
-		// current text and line number
-		const editorText: string = editor.document.getText();
-		const line: number = editor.selection.active.line;
-		// get tab info settings
-		const size: number =
-			typeof editor.options.tabSize === "number"
-				? editor.options.tabSize
-				: 4;
-		const hard: boolean = !editor.options.insertSpaces;
-		// initialize parser
-		const parser: pl.Parser = new pl.Parser(editorText, {
-			size,
-			hard,
-		});
+    if (editor) {
+        // current text and line number
+        const editorText: string = editor.document.getText();
+        const line: number = editor.selection.active.line;
+        // get tab info settings
+        const size: number =
+            typeof editor.options.tabSize === "number"
+                ? editor.options.tabSize
+                : 4;
+        const hard: boolean = !editor.options.insertSpaces;
+        // initialize parser
+        const parser: pl.Parser = new pl.Parser(editorText, {
+            size,
+            hard,
+        });
 
-		parser.parse();
-		const context: pl.LexNode[] = parser.context(line);
-		// build text
-		const contentString: string = createContextString(context, line);
+        parser.parse();
+        const context: pl.LexNode[] = parser.context(line);
+        // build text
+        const contentString: string = createContextString(context, line);
 
-		outputMessage(contentString);
-	} else {
-		window.showErrorMessage("No document currently active");
-	}
+        outputMessage(contentString);
+    } else {
+        window.showErrorMessage("No document currently active");
+    }
 }
 
 function createContextString(context: pl.LexNode[], line: number): string {
-	if (context.length < 1) {
-		throw new Error("Cannot create context string for empty context");
-	}
+    if (context.length < 1) {
+        throw new Error("Cannot create context string for empty context");
+    }
 
-	let contextString: string = `Line ${line + 1}`; // 1 based
-	// Print the current line
-	if (context[0].token && context[0].token.attr) {
-		let tokenTypeString: string = `${context[0].token.type.toString()}`;
+    let contextString: string = `Line ${line + 1}`; // 1 based
+    // Print the current line
+    if (context[0].token && context[0].token.attr) {
+        let tokenTypeString: string = `${context[0].token.type.toString()}`;
 		contextString += `: ${
 			tokenTypeString !== pl.PylexSymbol.STATEMENT ? tokenTypeString : ""
-		} ${context[0].token.attr.toString()}`;
-	} else if (
-		context[0].token?.type === pl.PylexSymbol.ELSE ||
-		context[0].token?.type === pl.PylexSymbol.TRY ||
-		context[0].token?.type === pl.PylexSymbol.EXCEPT
-	) {
-		let tokenTypeString: string = `${context[0].token.type.toString()}`;
-		contextString += ": " + tokenTypeString;
-	}
-	for (let i: number = 1; i < context.length; i++) {
-		const node: pl.LexNode = context[i];
-		const inside: string = "inside";
-		// Node contains information relevant to the current line
-		if (
-			node.token &&
-			node.token.type !== pl.PylexSymbol.EMPTY &&
-			node.token.type !== pl.PylexSymbol.STATEMENT
-		) {
-			contextString += ` ${inside} ${node.token.type.toString()}`;
-			if (node.token.attr) {
-				contextString += ` ${node.token.attr.toString()}`;
-			}
-		}
-		// Node is the document root
-		if (node.label === "root") {
-			// Append the name (relative path) of the document in the workspace
-			if (window.activeTextEditor?.document.uri) {
-				contextString += ` ${inside} ${workspace.asRelativePath(
-					window.activeTextEditor?.document.uri,
-				)}`;
-			} else {
-				contextString += ` ${inside} the Document`;
-			}
-			continue;
-		}
-	}
+            } ${context[0].token.attr.toString()}`;
+    } else if (
+        context[0].token?.type === pl.PylexSymbol.ELSE ||
+        context[0].token?.type === pl.PylexSymbol.TRY ||
+        context[0].token?.type === pl.PylexSymbol.EXCEPT
+    ) {
+        let tokenTypeString: string = `${context[0].token.type.toString()}`;
+        contextString += ": " + tokenTypeString;
+    }
+    for (let i: number = 1; i < context.length; i++) {
+        const node: pl.LexNode = context[i];
+        const inside: string = "inside";
+        // Node contains information relevant to the current line
+        if (
+            node.token &&
+            node.token.type !== pl.PylexSymbol.EMPTY &&
+            node.token.type !== pl.PylexSymbol.STATEMENT
+        ) {
+            contextString += ` ${inside} ${node.token.type.toString()}`;
+            if (node.token.attr) {
+                contextString += ` ${node.token.attr.toString()}`;
+            }
+        }
+        // Node is the document root
+        if (node.label === "root") {
+            // Append the name (relative path) of the document in the workspace
+            if (window.activeTextEditor?.document.uri) {
+                contextString += ` ${inside} ${workspace.asRelativePath(
+                    window.activeTextEditor?.document.uri,
+                )}`;
+            } else {
+                contextString += ` ${inside} the Document`;
+            }
+            continue;
+        }
+    }
 
-	return contextString;
+    return contextString;
 }
 
 /*
@@ -417,58 +419,58 @@ function createContextString(context: pl.LexNode[], line: number): string {
  * the value of `#mind-reader.reader.contextWindow`
  */
 function runCursorContext(): void {
-	const editor: TextEditor | undefined = window.activeTextEditor;
+    const editor: TextEditor | undefined = window.activeTextEditor;
 
-	if (!editor) {
-		window.showErrorMessage("RunCursorContext: No Active Editor");
-		return;
-	}
+    if (!editor) {
+        window.showErrorMessage("RunCursorContext: No Active Editor");
+        return;
+    }
 
-	const cursorPos: Position = editor.selection.active;
-	const text: string = editor.document.lineAt(cursorPos).text;
-	const windowSize: any = workspace
-		.getConfiguration("mind-reader")
-		.get("reader.contextWindow");
-	let trimmedText: string = text.trimStart(); // trim leading whitespace
-	const leadingWS: number = text.length - trimmedText.length; // # of characters of leading whitespace
-	let pos: number = leadingWS;
-	const maxPos: number = text.length;
-	// clamp cursor start/end to new range
-	let col: number = cursorPos.character; // effective column of the cursor position
+    const cursorPos: Position = editor.selection.active;
+    const text: string = editor.document.lineAt(cursorPos).text;
+    const windowSize: any = workspace
+        .getConfiguration("mind-reader")
+        .get("reader.contextWindow");
+    let trimmedText: string = text.trimStart(); // trim leading whitespace
+    const leadingWS: number = text.length - trimmedText.length; // # of characters of leading whitespace
+    let pos: number = leadingWS;
+    const maxPos: number = text.length;
+    // clamp cursor start/end to new range
+    let col: number = cursorPos.character; // effective column of the cursor position
 
-	trimmedText = trimmedText.trimEnd(); // trim trailing whitespace
+    trimmedText = trimmedText.trimEnd(); // trim trailing whitespace
 
-	if (col < leadingWS) {
-		// move effective start to first non-whitespace character in the line
-		col = leadingWS;
-	} else if (col > leadingWS + trimmedText.length - 1) {
-		// move effective end to last non-whitespace character in the line
-		col = leadingWS + trimmedText.length - 1;
-	}
+    if (col < leadingWS) {
+        // move effective start to first non-whitespace character in the line
+        col = leadingWS;
+    } else if (col > leadingWS + trimmedText.length - 1) {
+        // move effective end to last non-whitespace character in the line
+        col = leadingWS + trimmedText.length - 1;
+    }
 
-	// generate list of space separate words with range data (start, end)
-	// TODO: can find user position to be done in one pass
-	const spaceWords: any[] = [];
+    // generate list of space separate words with range data (start, end)
+    // TODO: can find user position to be done in one pass
+    const spaceWords: any[] = [];
 
-	while (pos < maxPos && trimmedText.length > 0) {
-		const word: string = trimmedText.replace(/ .*/, "");
+    while (pos < maxPos && trimmedText.length > 0) {
+        const word: string = trimmedText.replace(/ .*/, "");
 
-		spaceWords.push({
-			word,
-			start: pos,
-			end: pos + word.length,
-		});
+        spaceWords.push({
+            word,
+            start: pos,
+            end: pos + word.length,
+        });
 
-		// remove processed word from trimmed text
-		const oldText: string = trimmedText;
-		trimmedText = trimmedText.replace(/[^ ]+/, "").trimStart();
-		// update pos to start of next word
-		pos += oldText.length - trimmedText.length;
-	}
+        // remove processed word from trimmed text
+        const oldText: string = trimmedText;
+        trimmedText = trimmedText.replace(/[^ ]+/, "").trimStart();
+        // update pos to start of next word
+        pos += oldText.length - trimmedText.length;
+    }
 
-	// find word the user is in
-	let contextStart: number = -1;
-	let contextEnd: number = -1;
+    // find word the user is in
+    let contextStart: number = -1;
+    let contextEnd: number = -1;
 
 	for (let i: number = 0; i < spaceWords.length; i++) {
 		if (col >= spaceWords[i].start && col <= spaceWords[i].end) {
@@ -488,150 +490,194 @@ function runCursorContext(): void {
 }
 
 async function goToSyntaxErrors(): Promise<void> {
-	// Checks if there is an editor open
-	if (!window || !window.activeTextEditor) {
-		return;
-	}
+    // Checks if there is an editor open
+    if (!window || !window.activeTextEditor) {
+        return;
+    }
 
-	let diagnostics = languages.getDiagnostics(); // gets all current errors
-	let globalProblems = [];
-	const cursorPosition: Position = window.activeTextEditor.selection.active;
-	const currentFilePath: string = window.activeTextEditor.document.uri.path;
-	let nextProblemFileObj;
-	let nextProblemFileIndex;
-	let nextProblems;
+    let diagnostics = languages.getDiagnostics(); // gets all current errors
+    let globalProblems = [];
+    const cursorPosition: Position = window.activeTextEditor.selection.active;
+    const currentFilePath: string = window.activeTextEditor.document.uri.path;
+    let nextProblemFileObj;
+    let nextProblemFileIndex;
+    let nextProblems;
 
-	// creates array of objects
-	/*
-	{
-		uri: Uri
-		problems: { message: string, position: Position }[]
-	}
-	*/
-	for (let i = 0; i < diagnostics.length; i++) {
-		globalProblems.push({
-			uri: diagnostics[i][0],
-			problems: diagnostics[i][1]
-				.filter((diagnostics) => diagnostics.severity === 0) // keep errors
-				.map((res) => ({
-					message: res.message,
-					position: res.range.start,
-				})),
-		});
-	}
+    // creates array of objects
+    /*
+    {
+        uri: Uri
+        problems: { message: string, position: Position }[]
+    }
+    */
+    for (let i = 0; i < diagnostics.length; i++) {
+        globalProblems.push({
+            uri: diagnostics[i][0],
+            problems: diagnostics[i][1]
+                .filter((diagnostics) => diagnostics.severity === 0) // keep errors
+                .map((res) => ({
+                    message: res.message,
+                    position: res.range.start,
+                })),
+        });
+    }
 
-	// removes any stored files with no problems
-	globalProblems = globalProblems.filter(
-		(diagnostics) => diagnostics.problems.length > 0,
-	);
+    // removes any stored files with no problems
+    globalProblems = globalProblems.filter(
+        (diagnostics) => diagnostics.problems.length > 0,
+    );
 
-	// checks if there are any problems
-	if (globalProblems.length === 0) {
-		return;
-	}
+    // checks if there are any problems
+    if (globalProblems.length === 0) {
+        return;
+    }
 
-	// get the next problem file's object and index
-	nextProblemFileObj = globalProblems.find(
-		(e) => e.uri.path === currentFilePath,
-	);
-	nextProblemFileIndex = globalProblems.findIndex(
-		(e) => e.uri.path === currentFilePath,
-	);
+    // get the next problem file's object and index
+    nextProblemFileObj = globalProblems.find(
+        (e) => e.uri.path === currentFilePath,
+    );
+    nextProblemFileIndex = globalProblems.findIndex(
+        (e) => e.uri.path === currentFilePath,
+    );
 
-	// select first error file if cursor is on file without errors
-	if (nextProblemFileObj === undefined) {
-		nextProblemFileIndex = 0;
-		nextProblemFileObj = globalProblems[0];
-		await window.showTextDocument(nextProblemFileObj.uri);
-		moveCursorBeginning();
-		return;
-	}
+    // select first error file if cursor is on file without errors
+    if (nextProblemFileObj === undefined) {
+        nextProblemFileIndex = 0;
+        nextProblemFileObj = globalProblems[0];
+        await checkTabGroup(nextProblemFileObj);
+        await window.showTextDocument(nextProblemFileObj.uri);
+        moveCursorBeginning();
+        return;
+    }
 
-	// gets the next problem in the problems array
-	nextProblems = nextProblemFileObj!.problems.filter((problem) => {
-		if (problem.position.line > cursorPosition.line) {
-			return true;
-		}
-		if (
-			problem.position.line === cursorPosition.line &&
-			problem.position.character > cursorPosition.character
-		) {
-			return true;
-		} else {
-			return false;
-		}
-	});
+    // gets the next problem in the problems array
+    nextProblems = nextProblemFileObj!.problems.filter((problem) => {
+        if (problem.position.line > cursorPosition.line) {
+            return true;
+        }
+        if (
+            problem.position.line === cursorPosition.line &&
+            problem.position.character > cursorPosition.character
+        ) {
+            return true;
+        } else {
+            return false;
+        }
+    });
 
-	// if statement for moving cursor position or changing activeTextEditor
-	if (nextProblems.length > 0) {
-		// next problem within same file
-		window.activeTextEditor.selection = new Selection(
-			nextProblems[0].position,
-			nextProblems[0].position,
-		);
+    // where to move cursor's position or change activeTextEditor
+    if (nextProblems.length > 0) {  // next problem within same file
+        window.activeTextEditor.selection = new Selection(
+            nextProblems[0].position,
+            nextProblems[0].position,
+        );
         window.activeTextEditor.revealRange(new Range(nextProblems[0].position, nextProblems[0].position));
 
         let path = window.activeTextEditor.document.uri.fsPath;
         path = path.replace("\/", "\\");
-		let fileName = path.match(/((?:[^\\|\/]*){1})$/g)?.toString();
-		fileName = fileName!.replace(',', '');
-		let message = fileName + ": " + nextProblems[0].message;
+        let fileName = path.match(/((?:[^\\|\/]*){1})$/g)?.toString();
+        fileName = fileName!.replace(',', '');
+        let message = fileName + ": " + nextProblems[0].message;
 
-		outputMessage(message);
-	} else if (nextProblems.length === 0) {
-		// next problem not in same file
-		if (nextProblemFileIndex < globalProblems.length - 1) {
-			// next problem in next file
-			nextProblemFileObj = globalProblems[nextProblemFileIndex + 1];
-			await window.showTextDocument(nextProblemFileObj.uri);
-			moveCursorBeginning();
-		} else {
-			// last problem, go to first problem of first file
-			await window.showTextDocument(globalProblems[0].uri);
-			moveCursorBeginning();
-		}
-	}
+        outputMessage(message);
+    } else if (nextProblems.length === 0) {
+        // next problem not in same file
+        if (nextProblemFileIndex < globalProblems.length - 1) {
+            // next problem in next file
+            nextProblemFileObj = globalProblems[nextProblemFileIndex + 1];
+            await checkTabGroup(nextProblemFileObj);
+            await window.showTextDocument(nextProblemFileObj.uri);
+            moveCursorBeginning();
+        } else {
+            // last problem, go to first problem of first file
+            await checkTabGroup(globalProblems[0]);
+            await window.showTextDocument(globalProblems[0].uri);
+            moveCursorBeginning();
+        }
+    }
+}
+
+function searchTab(path: string) {
+    var allTabGroups: readonly TabGroup[] = window.tabGroups.all;
+    var activeTabGroupIndex: number = getActiveTabIndex(allTabGroups);
+    for (let i = 0; i < allTabGroups.length; i++) {
+        for (let j = 0; j < allTabGroups[i].tabs.length; j++) {
+            let obj: unknown = allTabGroups[i].tabs[j].input;
+            if (typeof obj === 'object' && obj !== null && 'uri' in obj) {
+                if (typeof obj.uri === 'object' && obj.uri !== null && 'path' in obj.uri) {
+                    if (obj.uri.path === path) {
+                        return { tabFound: true, tabGroupIndex: i, activeTabGroupIndex: activeTabGroupIndex };
+                    }
+                }
+            }
+        }
+    }
+    return { tabFound: false, tabGroupIndex: -1, activeTabGroupIndex: activeTabGroupIndex };
+}
+
+function getActiveTabIndex(allTabGroups: readonly TabGroup[]) {
+    for (let i = 0; i < allTabGroups.length; i++) {
+        if (allTabGroups[i] === window.tabGroups.activeTabGroup) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+async function checkTabGroup(nextProblemFileObj: any) {
+    const { tabFound, tabGroupIndex, activeTabGroupIndex } = searchTab(nextProblemFileObj.uri.path);
+    if (tabFound && tabGroupIndex !== activeTabGroupIndex) {   // next file is in another tabGroup
+        if (activeTabGroupIndex < tabGroupIndex) {
+            for (let i = activeTabGroupIndex; i < tabGroupIndex; i++) {
+                await commands.executeCommand("workbench.action.focusNextGroup");
+            }
+        } else if (activeTabGroupIndex > tabGroupIndex) {
+            for (let i = activeTabGroupIndex; i > tabGroupIndex; i--) {
+                await commands.executeCommand("workbench.action.focusPreviousGroup");
+            }
+        }
+    }
 }
 
 // Helper functions to move Cursor to beginning or end
 export function moveCursorBeginning(): void {
-	const editor = window.activeTextEditor;
+    const editor = window.activeTextEditor;
 
-	//Throw error if no editor open
-	if (!editor) {
-		window.showErrorMessage("MoveCursorBeginning: No Active Editor");
-		return;
-	}
+    //Throw error if no editor open
+    if (!editor) {
+        window.showErrorMessage("MoveCursorBeginning: No Active Editor");
+        return;
+    }
 
-	let newPosition: Position;
+    let newPosition: Position;
 
-	newPosition = new Position(0, 0); // Assign  newPosition to beginning
+    newPosition = new Position(0, 0); // Assign  newPosition to beginning
 
-	const newSelection = new Selection(newPosition, newPosition);
-	editor.selection = newSelection; // Apply change to editor
+    const newSelection = new Selection(newPosition, newPosition);
+    editor.selection = newSelection; // Apply change to editor
 
-	editor.revealRange(editor.selection, 1); // Make sure cursor is within range
-	window.showTextDocument(editor.document, editor.viewColumn); // You are able to type without reclicking in document
+    editor.revealRange(editor.selection, 1); // Make sure cursor is within range
+    window.showTextDocument(editor.document, editor.viewColumn); // You are able to type without reclicking in document
 }
 
 export function moveCursorEnd(): void {
-	const editor = window.activeTextEditor;
+    const editor = window.activeTextEditor;
 
-	//Throw error if no editor open
-	if (!editor) {
-		window.showErrorMessage("MoveCursorBeginning: No Active Editor");
-		return;
-	}
+    //Throw error if no editor open
+    if (!editor) {
+        window.showErrorMessage("MoveCursorBeginning: No Active Editor");
+        return;
+    }
 
-	let newPosition: Position;
+    let newPosition: Position;
 
-	const lastLine = editor.document.lineCount - 1; // Get last line
-	const lastCharacter = editor.document.lineAt(lastLine).text.length; // Get last character in last line
-	newPosition = new Position(lastLine, lastCharacter); // Assign new position to end
+    const lastLine = editor.document.lineCount - 1; // Get last line
+    const lastCharacter = editor.document.lineAt(lastLine).text.length; // Get last character in last line
+    newPosition = new Position(lastLine, lastCharacter); // Assign new position to end
 
-	const newSelection = new Selection(newPosition, newPosition);
-	editor.selection = newSelection; // Apply change to editor
+    const newSelection = new Selection(newPosition, newPosition);
+    editor.selection = newSelection; // Apply change to editor
 
-	editor.revealRange(editor.selection, 1); // Make sure cursor is within range
-	window.showTextDocument(editor.document, editor.viewColumn); // You are able to type without reclicking in document
+    editor.revealRange(editor.selection, 1); // Make sure cursor is within range
+    window.showTextDocument(editor.document, editor.viewColumn); // You are able to type without reclicking in document
 }


### PR DESCRIPTION
## Changes
- added ability to jump between tabgroups when using H8, as long as the next file is in another tabgroup
- updated types/vscode to update vscode ts types

## Testing
1. Run `npm i` to update packages
2. Run extension
3. open mulitple tabs with errors and split them into different tabgroups
    - you can do that by clicking and dragging a tab to one side of the window. something like this:
        ![image](https://github.com/kelsvilla/LegoMindstormsVSExtension/assets/89543725/77cad2b5-0cbc-44ae-8968-7e87ba485281)
4. Press "Go to Syntax Errors" command on Access Actions or press Ctrl/Cmd + Shift + Space

## Notes
- be sure to run `npm i` because I updated `@types/vscode` in package.json
- If you click or use the hotkey fast enough (ie. holding it), new tabs may open. I suspect that it has to do with the timing of finding the tabgroup and opening the text document.