### PR TITLE
Tabgroup jump fixes

### DIFF
--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -551,6 +551,10 @@ async function goToSyntaxErrors(): Promise<void> {
             selection: new Range(nextProblemFileObj.problems[0].position, nextProblemFileObj.problems[0].position),
             viewColumn: tabGroup
         });
+
+        let message = generateErrorMessage(window.activeTextEditor, nextProblemFileObj.problems[0].message);
+        outputMessage(message);
+
         return;
     }
 
@@ -577,12 +581,7 @@ async function goToSyntaxErrors(): Promise<void> {
         );
         window.activeTextEditor.revealRange(new Range(nextProblems[0].position, nextProblems[0].position));
 
-        let path = window.activeTextEditor.document.uri.fsPath;
-        path = path.replace("\/", "\\");
-        let fileName = path.match(/((?:[^\\|\/]*){1})$/g)?.toString();
-        fileName = fileName!.replace(',', '');
-        let message = fileName + ": " + nextProblems[0].message;
-
+        let message = generateErrorMessage(window.activeTextEditor, nextProblems[0].message);
         outputMessage(message);
     } else if (nextProblems.length === 0) {
         // next problem not in same file
@@ -594,6 +593,9 @@ async function goToSyntaxErrors(): Promise<void> {
                 selection: new Range(nextProblemFileObj.problems[0].position, nextProblemFileObj.problems[0].position),
                 viewColumn: tabGroup
             });
+
+            let message = generateErrorMessage(window.activeTextEditor, nextProblemFileObj.problems[0].message);
+            outputMessage(message);
         } else {
             // last problem, go to first problem of first file
             const tabGroup = getTabGroupIndex(globalProblems[0]);
@@ -601,6 +603,9 @@ async function goToSyntaxErrors(): Promise<void> {
                 selection: new Range(globalProblems[0].problems[0].position, globalProblems[0].problems[0].position),
                 viewColumn: tabGroup
             });
+
+            let message = generateErrorMessage(window.activeTextEditor, globalProblems[0].problems[0].message);
+            outputMessage(message);
         }
     }
 }
@@ -667,4 +672,14 @@ export function moveCursorEnd(): void {
 
     editor.revealRange(editor.selection, 1); // Make sure cursor is within range
     window.showTextDocument(editor.document, editor.viewColumn); // You are able to type without reclicking in document
+}
+
+function generateErrorMessage(textEditor: TextEditor, nextProblemMessage: string): string {
+    let path = textEditor.document.uri.fsPath;
+    path = path.replace("\/", "\\");
+    let fileName = path.match(/((?:[^\\|\/]*){1})$/g)?.toString();
+    fileName = fileName!.replace(',', '');
+    let message = fileName + ": " + nextProblemMessage;
+
+    return message;
 }

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -498,7 +498,7 @@ async function goToSyntaxErrors(): Promise<void> {
     let diagnostics = languages.getDiagnostics(); // gets all current errors
     let globalProblems = [];
     const cursorPosition: Position = window.activeTextEditor.selection.active;
-    const currentFilePath: string = window.activeTextEditor.document.uri.path;
+    const currentFilePath: string = window.activeTextEditor.document.uri.toString();
     let nextProblemFileObj;
     let nextProblemFileIndex;
     let nextProblems;
@@ -534,10 +534,10 @@ async function goToSyntaxErrors(): Promise<void> {
 
     // get the next problem file's object and index
     nextProblemFileObj = globalProblems.find(
-        (e) => e.uri.path === currentFilePath,
+        (e) => e.uri.toString() === currentFilePath,
     );
     nextProblemFileIndex = globalProblems.findIndex(
-        (e) => e.uri.path === currentFilePath,
+        (e) => e.uri.toString() === currentFilePath,
     );
 
     // select first error file if cursor is on file without errors

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -597,25 +597,22 @@ async function goToSyntaxErrors(): Promise<void> {
     }
 }
 
-function searchTab(path: string) {
+async function searchTab(path: string) {
     var allTabGroups: readonly TabGroup[] = window.tabGroups.all;
-    var activeTabGroupIndex: number = getActiveTabIndex(allTabGroups);
+    var activeTabGroupIndex: number = await getActiveTabIndex(allTabGroups);
     for (let i = 0; i < allTabGroups.length; i++) {
         for (let j = 0; j < allTabGroups[i].tabs.length; j++) {
-            let obj: unknown = allTabGroups[i].tabs[j].input;
-            if (typeof obj === 'object' && obj !== null && 'uri' in obj) {
-                if (typeof obj.uri === 'object' && obj.uri !== null && 'path' in obj.uri) {
-                    if (obj.uri.path === path) {
-                        return { tabFound: true, tabGroupIndex: i, activeTabGroupIndex: activeTabGroupIndex };
-                    }
-                }
+            let obj: any = allTabGroups[i].tabs[j].input as any;
+
+            if (obj.uri.path === path) {
+                return { tabFound: true, tabGroupIndex: i, activeTabGroupIndex: activeTabGroupIndex };
             }
         }
     }
     return { tabFound: false, tabGroupIndex: -1, activeTabGroupIndex: activeTabGroupIndex };
 }
 
-function getActiveTabIndex(allTabGroups: readonly TabGroup[]) {
+async function getActiveTabIndex(allTabGroups: readonly TabGroup[]) {
     for (let i = 0; i < allTabGroups.length; i++) {
         if (allTabGroups[i] === window.tabGroups.activeTabGroup) {
             return i;
@@ -625,7 +622,7 @@ function getActiveTabIndex(allTabGroups: readonly TabGroup[]) {
 }
 
 async function checkTabGroup(nextProblemFileObj: any) {
-    const { tabFound, tabGroupIndex, activeTabGroupIndex } = searchTab(nextProblemFileObj.uri.path);
+    const { tabFound, tabGroupIndex, activeTabGroupIndex } = await searchTab(nextProblemFileObj.uri.path);
     if (tabFound && tabGroupIndex !== activeTabGroupIndex) {   // next file is in another tabGroup
         if (activeTabGroupIndex < tabGroupIndex) {
             for (let i = activeTabGroupIndex; i < tabGroupIndex; i++) {

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -10,8 +10,6 @@ import {
 	window,
 	workspace,
     Range,
-    commands,
-    TabGroup,
     Uri,
     TabInputText
 } from "vscode";


### PR DESCRIPTION
## Changes
- fixed typings error when compiling the extension
- fixed file duplication when jumping between 3+ tabgroups
- added error message generating function

## Testing (compiling)
- run `npm run compile` in the terminal

## Testing (tabgroups)
Follow instructions in #28 

Related cards:
https://trello.com/c/os60LBnz/3-jump-tabgroups-feature-has-property-errors-and-tab-duplication-bug