### PR TITLE
Adjustable tts speed

### DIFF
--- a/package.json
+++ b/package.json
@@ -350,7 +350,7 @@
 				"key": "Ctrl+Shift+/ Ctrl+Shift+/",
 				"mac": "Cmc+Shift+[Slash] Cmc+Shift+[Slash]"
 			},
-			{ 
+			{
 				"command": "mind-reader.startStreaming",
 				"key": "ctrl+Shift+/ V",
 				"mac": "Cmd+Shift+[Slash] V"
@@ -847,7 +847,8 @@
 		"tone": "^14.7.77",
 		"vscode-languageclient": "^5.1.0-next.9",
 		"web-audio-api": "^0.2.2",
-		"ws": "^6.2.2"
+		"ws": "^6.2.2",
+		"zod": "^3.22.4"
 	},
 	"icon": "media/logo.png",
 	"description": "An extension with additional features for Lego Mindstorm development.",

--- a/package.json
+++ b/package.json
@@ -578,6 +578,18 @@
 						"order": 2,
 						"type": "string",
 						"markdownDescription": "The default port to try and establish a connection on."
+					},
+					"mind-reader.textToSpeech.readingSpeed": {
+						"order": 4,
+						"type": "number",
+						"description": "The speed that the Text to Speech function will read.",
+						"default": 1
+					},
+					"mind-reader.textToSpeech.isEnabled": {
+						"order": 5,
+						"type": "boolean",
+						"description": "Enable/Disable Text to Speech.",
+						"default": false
 					}
 				}
 			},

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -83,17 +83,19 @@ export const textCommands: CommandEntry[] = [
  **    TO-USE: set calculateLeadingSpaces to false
  */
 
+let shouldSpeak: boolean;
+export function setShouldSpeak() {
+    shouldSpeak = Configuration.GetInstance().get()["textToSpeech"]["isEnabled"];
+}
+
 function outputMessage(message: string) {
     let readingSpeed: number = Configuration.GetInstance().get()["textToSpeech"]["readingSpeed"];
-    let shouldSpeak: boolean = Configuration.GetInstance().get()["textToSpeech"]["isEnabled"];
 
     window.showInformationMessage(message);
     shouldSpeak === true ? say.speak(message, undefined, readingSpeed) : undefined;
 }
 
 function toggleTTS() {
-    let shouldSpeak: boolean = Configuration.GetInstance().get()["textToSpeech"]["isEnabled"];
-
     shouldSpeak = !shouldSpeak;
     shouldSpeak
         ? window.showInformationMessage("Text to Speech Activated")

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -14,6 +14,7 @@ import {
     TabGroup
 } from "vscode";
 import { CommandEntry } from "./commandEntry";
+import { Configuration } from "../util";
 
 export const textCommands: CommandEntry[] = [
     {
@@ -81,14 +82,18 @@ export const textCommands: CommandEntry[] = [
  **
  **    TO-USE: set calculateLeadingSpaces to false
  */
-let shouldSpeak = false;
 
 function outputMessage(message: string) {
+    let readingSpeed: number = Configuration.GetInstance().get()["textToSpeech"]["readingSpeed"];
+    let shouldSpeak: boolean = Configuration.GetInstance().get()["textToSpeech"]["isEnabled"];
+
     window.showInformationMessage(message);
-    shouldSpeak === true ? say.speak(message) : undefined;
+    shouldSpeak === true ? say.speak(message, undefined, readingSpeed) : undefined;
 }
 
 function toggleTTS() {
+    let shouldSpeak: boolean = Configuration.GetInstance().get()["textToSpeech"]["isEnabled"];
+
     shouldSpeak = !shouldSpeak;
     shouldSpeak
         ? window.showInformationMessage("Text to Speech Activated")

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import Logger from "./log";
 import { installer } from "./pythonManager";
 import path = require("path");
 import {toggleLineHighlight, highlightDeactivate} from "./commands/lineHighlighter";
+import { setShouldSpeak } from "./commands/text";
 
 import {
 	accessCommands,
@@ -72,6 +73,7 @@ export function activate(context: vscode.ExtensionContext) {
 	vscode.window.registerTreeDataProvider("hubActions", hubProvider);
 
 	toggleLineHighlight();
+	setShouldSpeak();
 
 	vscode.window.showInformationMessage("Mind Reader finished loading!");
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import {
 	midicommands,
 	lineHighlightercommands
 } from "./commands";
+import { Configuration } from "./util";
 
 //import { runClient } from "./client";
 
@@ -28,6 +29,8 @@ export const logger = new Logger(outputChannel);
 let parser: pl.Parser = new pl.Parser();
 export const rootDir = path.dirname(__filename);
 export function activate(context: vscode.ExtensionContext) {
+	let config = new Configuration(context);
+
 	//python packages installer
 	installer();
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,165 @@
+import * as fs from "fs";
+import * as path from "path";
+// import { AnyNode, Element } from "cheerio";
+import * as vscode from "vscode";
+import * as z from "zod";
+import { readdirSync } from "fs";
+import { join } from "path";
+
+// export function isElement(node: AnyNode): node is Element {
+//   return node.nodeType === NodeType.ELEMENT_NODE;
+// }
+
+// export enum NodeType {
+//   ELEMENT_NODE = 1,
+//   ATTRIBUTE_NODE = 2,
+//   TEXT_NODE = 3,
+//   PROCESSING_INSTRUCTION_NODE = 7,
+//   COMMENT_NODE = 9,
+// }
+
+//Singleton class that allows for synchronized settings across the project with auto-updating
+export class Configuration {
+    static #_instance: any;
+    #config!: ConfigType;
+
+    constructor(context?: vscode.ExtensionContext) {
+        if (!Configuration.#_instance) {
+            if (context) {
+                Configuration.#_instance = this;
+                this.initialize(context);
+            } else {
+                throw new Error("Please initialize Configuration with a vscode context first.");
+            }
+        }
+        return Configuration.#_instance;
+    }
+
+    static GetInstance(): Configuration {
+        if (!Configuration.#_instance) {
+            throw new Error("Please initialize Configuration with a vscode context first.");
+        }
+        return Configuration.#_instance;
+    }
+
+    //Called once upon creation of first instance
+    initialize(context: vscode.ExtensionContext) {
+        const config = vscode.workspace.getConfiguration("accessibilityChecker");
+        this.#config = ConfigSchema.parse(config);
+        if (!this.#config) {
+            throw new Error("Error retrieving config");
+        }
+        context.subscriptions.push(
+            vscode.workspace.onDidChangeConfiguration((event) => {
+                if (event.affectsConfiguration("accessibilityChecker")) {
+                    const config = vscode.workspace.getConfiguration("accessibilityChecker");
+                    this.#config = ConfigSchema.parse(config);
+                }
+            })
+        );
+    }
+
+    get(section?: string): ConfigType {
+        return this.#config;
+    }
+}
+
+export const ConfigSchema = z.object({
+    operable: z.object({
+        enoughTime: z.object({
+            "Marquee element used": z.boolean(),
+            "Meta refresh with a time-out is used": z.boolean(),
+        }),
+        keyboardAccessible: z.object({
+            "onmousedown event missing onkeydown event": z.boolean(),
+            "onmouseover event handler missing onfocus event handler": z.boolean(),
+            "script not keyboard accessible - onmouse missing onblur": z.boolean(),
+            "script not keyboard accessible - onmouseout missing onblur": z.boolean(),
+        }),
+        navigable: z.object({
+            "Anchor contains no text.": z.boolean(),
+            "Document missing title element": z.boolean(),
+            "Header nesting - header following h1 is incorrect.": z.boolean(),
+            "Header nesting - header following h2 is incorrect.": z.boolean(),
+            "Header nesting - header following h3 is incorrect.": z.boolean(),
+            "Header nesting - header following h4 is incorrect.": z.boolean(),
+            "Header nesting - header following h5 is incorrect.": z.boolean(),
+            "Include an href attribute to make text a hyperlink": z.boolean(),
+            "There should only be one <h1> per page": z.boolean(),
+            "title element is empty": z.boolean(),
+        }),
+    }),
+    understandable: z.object({
+        inputAssistance: z.object({
+            "input element has more than one associated label": z.boolean(),
+            "label text is empty": z.boolean(),
+        }),
+        readable: z.object({
+            "document has invalid language code": z.boolean(),
+            "document language not identified": z.boolean(),
+        }),
+    }),
+    robust: z.object({
+        compatible: z.object({
+            "id attribute is not unique": z.boolean(),
+        }),
+    }),
+    perceivable: z.object({
+        adaptable: z.object({
+            "button has no text in label.": z.boolean(),
+            "Buttons should have button type": z.boolean(),
+            "Include a caption for each table.": z.boolean(),
+            "input element, type of 'checkbox', has no text in label.": z.boolean(),
+            "input element, type of 'checkbox', missing an associated label.": z.boolean(),
+            "input element, type of 'file', has no text in label.": z.boolean(),
+            "input element, type of 'file', missing an associated label.": z.boolean(),
+            "input element, type of 'password', has no text in label.": z.boolean(),
+            "input element, type of 'password', missing an associated label.": z.boolean(),
+            "input element, type of 'radio', has no text in label.": z.boolean(),
+            "input element, type of 'radio', missing an associated label.": z.boolean(),
+            "input element, type of 'text', missing an associated label.": z.boolean(),
+            "input element, type of 'text', has no text in label.": z.boolean(),
+            "Label text is empty for select statement.": z.boolean(),
+            "select element missing an associated label.": z.boolean(),
+            "Select elements should only have one associated label": z.boolean(),
+            "textarea element missing an associated label.": z.boolean(),
+            "Textarea elements should only have one associated label": z.boolean(),
+        }),
+        distinguishable: z.object({
+            "b (bold) element used": z.boolean(),
+            "bold element used": z.boolean(),
+            "font used.": z.boolean(),
+            "i (italic) element used": z.boolean(),
+            "italic element used": z.boolean(),
+            "Video and audio tags should have control attribute for pausing and volume": z.boolean(),
+        }),
+        textAlternatives: z.object({
+            "Image used as anchor is missing valid Alt text.": z.boolean(),
+            "img element missing alt attribute": z.boolean(),
+            "input element has alt attribute": z.boolean(),
+        }),
+    }),
+    get: z.function(),
+});
+
+export type ConfigType = z.infer<typeof ConfigSchema>;
+
+export function Writeable(filepath: string, options: { append: boolean } = { append: false }) {
+    const rootdir = path.dirname(__filename).replace(`${path.sep}dist`, "");
+    filepath = `${rootdir}${path.sep}${filepath}`;
+    if (!options.append && fs.existsSync(filepath)) fs.unlinkSync(filepath);
+    const stream = fs.createWriteStream(filepath, { flags: "a" });
+    return function pipe(data: string) {
+        return new Promise((res, rej) => {
+            stream.write(data, (error) => {
+                error ? rej("error writing") : res("Success");
+            });
+        });
+    };
+}
+
+export function walk(dir: string): string[] {
+    return readdirSync(dir, { withFileTypes: true })
+        .flatMap((file) => (file.isDirectory() ? walk(join(dir, file.name)) : join(dir, file.name)))
+        .filter((file) => path.extname(file) === ".html");
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -44,15 +44,15 @@ export class Configuration {
 
     //Called once upon creation of first instance
     initialize(context: vscode.ExtensionContext) {
-        const config = vscode.workspace.getConfiguration("accessibilityChecker");
+        const config = vscode.workspace.getConfiguration("mind-reader");
         this.#config = ConfigSchema.parse(config);
         if (!this.#config) {
             throw new Error("Error retrieving config");
         }
         context.subscriptions.push(
             vscode.workspace.onDidChangeConfiguration((event) => {
-                if (event.affectsConfiguration("accessibilityChecker")) {
-                    const config = vscode.workspace.getConfiguration("accessibilityChecker");
+                if (event.affectsConfiguration("mind-reader")) {
+                    const config = vscode.workspace.getConfiguration("mind-reader");
                     this.#config = ConfigSchema.parse(config);
                 }
             })
@@ -65,79 +65,9 @@ export class Configuration {
 }
 
 export const ConfigSchema = z.object({
-    operable: z.object({
-        enoughTime: z.object({
-            "Marquee element used": z.boolean(),
-            "Meta refresh with a time-out is used": z.boolean(),
-        }),
-        keyboardAccessible: z.object({
-            "onmousedown event missing onkeydown event": z.boolean(),
-            "onmouseover event handler missing onfocus event handler": z.boolean(),
-            "script not keyboard accessible - onmouse missing onblur": z.boolean(),
-            "script not keyboard accessible - onmouseout missing onblur": z.boolean(),
-        }),
-        navigable: z.object({
-            "Anchor contains no text.": z.boolean(),
-            "Document missing title element": z.boolean(),
-            "Header nesting - header following h1 is incorrect.": z.boolean(),
-            "Header nesting - header following h2 is incorrect.": z.boolean(),
-            "Header nesting - header following h3 is incorrect.": z.boolean(),
-            "Header nesting - header following h4 is incorrect.": z.boolean(),
-            "Header nesting - header following h5 is incorrect.": z.boolean(),
-            "Include an href attribute to make text a hyperlink": z.boolean(),
-            "There should only be one <h1> per page": z.boolean(),
-            "title element is empty": z.boolean(),
-        }),
-    }),
-    understandable: z.object({
-        inputAssistance: z.object({
-            "input element has more than one associated label": z.boolean(),
-            "label text is empty": z.boolean(),
-        }),
-        readable: z.object({
-            "document has invalid language code": z.boolean(),
-            "document language not identified": z.boolean(),
-        }),
-    }),
-    robust: z.object({
-        compatible: z.object({
-            "id attribute is not unique": z.boolean(),
-        }),
-    }),
-    perceivable: z.object({
-        adaptable: z.object({
-            "button has no text in label.": z.boolean(),
-            "Buttons should have button type": z.boolean(),
-            "Include a caption for each table.": z.boolean(),
-            "input element, type of 'checkbox', has no text in label.": z.boolean(),
-            "input element, type of 'checkbox', missing an associated label.": z.boolean(),
-            "input element, type of 'file', has no text in label.": z.boolean(),
-            "input element, type of 'file', missing an associated label.": z.boolean(),
-            "input element, type of 'password', has no text in label.": z.boolean(),
-            "input element, type of 'password', missing an associated label.": z.boolean(),
-            "input element, type of 'radio', has no text in label.": z.boolean(),
-            "input element, type of 'radio', missing an associated label.": z.boolean(),
-            "input element, type of 'text', missing an associated label.": z.boolean(),
-            "input element, type of 'text', has no text in label.": z.boolean(),
-            "Label text is empty for select statement.": z.boolean(),
-            "select element missing an associated label.": z.boolean(),
-            "Select elements should only have one associated label": z.boolean(),
-            "textarea element missing an associated label.": z.boolean(),
-            "Textarea elements should only have one associated label": z.boolean(),
-        }),
-        distinguishable: z.object({
-            "b (bold) element used": z.boolean(),
-            "bold element used": z.boolean(),
-            "font used.": z.boolean(),
-            "i (italic) element used": z.boolean(),
-            "italic element used": z.boolean(),
-            "Video and audio tags should have control attribute for pausing and volume": z.boolean(),
-        }),
-        textAlternatives: z.object({
-            "Image used as anchor is missing valid Alt text.": z.boolean(),
-            "img element missing alt attribute": z.boolean(),
-            "input element has alt attribute": z.boolean(),
-        }),
+    textToSpeech: z.object({
+        readingSpeed: z.number(),
+        isEnabled: z.boolean()
     }),
     get: z.function(),
 });


### PR DESCRIPTION
## Changes
- implemented adjustable TTS reading speed
- added config class that holds settings for TTS
- moved shouldSpeak to settings and held in config class
- added zod package for config class
- added configurations for TTS

## Testing
1. run `npm i`
2. run the extension
3. play around with the new TTS settings `Reading speed` and `Is Enabled`
4. have a python file with errors
5. press Ctrl/Cmd + Shift + Space
6. TTS should read if `Is Enabled` is true and reads at the speed you set in `Reading Speed`

## Notes
~~- currently breaks the toggle tts feature. working on fixing that. just making this PR just so I don't forget. will update later~~
- TTS toggle feature in Access Actions does not directly change the settings for VS Code. It is temporary